### PR TITLE
adding .spi.yml file to opt into documentation for SwiftPackageIndex

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,3 @@ version: 1
 builder:
   configs:
     - documentation_targets: [Numerix]
-      scheme: Numerix

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Numerix]
+      scheme: Numerix


### PR DESCRIPTION
This adds in the .spi.yml file that will opt you in to hosted documentation for [your project at the Swift Package Index](https://swiftpackageindex.com/wigging/numerix).